### PR TITLE
Develop/add more tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,10 @@ env:
 r:
   - release
 
-#install external dependencies, such as rgeos
+#install external dependencies, such as rgeos. With the newest Travis-CI update, it would
+#appear that the binary "libudunits2-dev" is now necessary to test R software packages.
 before_install:
+  - sudo apt-get install libudunits2-dev
   - sudo apt-get install r-cran-rgeos
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - R -e 'install.packages("devtools")'
   - R -e 'devtools::install_deps(dependencies = TRUE)'
 #This will catch installation issues
-  - R -e 'devtools::install_github("semmons1/SDraw")'
+  - R -e 'devtools::install_github("tmcd82070/SDraw")'
   - R -e 'install.packages("sp")'
   - R -e 'install.packages("spsurvey")' #deldir is a dependency that should be installed with spsurvey
   - R -e 'install.packages("covr")' #specifically for codecovr feature

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,12 @@ env:
 r:
   - release
 
-#install external dependencies, such as rgeos. With the newest Travis-CI update, it would
-#appear that the binary "libudunits2-dev" is now necessary to test R software packages.
+#Install external dependencies, such as rgeos. With the newest Travis-CI update that utilizes the Ubuntu 18 distro, 
+#it would appear that the binaries "libudunits2-dev, and libgdal-dev" 
+#are now necessary to test R software packages.
 before_install:
   - sudo apt-get install libudunits2-dev
+  - sudo apt-get install libgdal-dev
   - sudo apt-get install r-cran-rgeos
 
 install:


### PR DESCRIPTION
Hotfix for Travis-CI binaries. Two new libraries needed to be specified in order to enable compatibility between R and the newest version of Ubuntu (Xenial).