### PR TITLE
Travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ install:
 script:
   - R CMD build --no-build-vignettes --no-manual .
   - R CMD check --no-build-vignettes --no-manual --timings *tar.gz
+  - Rscript -e 'devtools::install();devtools::test(stop_on_failure = TRUE)'
   - Rscript -e 'covr::package_coverage()'
-  #- Rscript -e 'devtools::install();devtools::test(stop_on_failure = TRUE)'
+  
 
 #report coverage for release version
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,6 @@ script:
   - R CMD build --no-build-vignettes --no-manual .
   - R CMD check --no-build-vignettes --no-manual --timings *tar.gz
   - Rscript -e 'devtools::install();devtools::test(stop_on_failure = TRUE)'
-  - Rscript -e 'covr::package_coverage()'
-  
 
 #report coverage for release version
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,11 @@ install:
 script:
   - R CMD build --no-build-vignettes --no-manual .
   - R CMD check --no-build-vignettes --no-manual --timings *tar.gz
+  - Rscript -e 'devtools::install();devtools::test_package()'
 
 #report coverage for release version
 after_success:
   - test $TRAVIS_R_VERSION_STRING = 'release' && Rscript -e 'covr::codecov()'
-  - Rscript -e 'devtools::install();devtools::test()'
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ install:
 script:
   - R CMD build --no-build-vignettes --no-manual .
   - R CMD check --no-build-vignettes --no-manual --timings *tar.gz
-  - Rscript -e 'devtools::install();devtools::test_package()'
+  - Rscript -e 'covr::package_coverage()'
+  #- Rscript -e 'devtools::install();devtools::test(stop_on_failure = TRUE)'
 
 #report coverage for release version
 after_success:

--- a/tests/testthat/test-bas.point.R
+++ b/tests/testthat/test-bas.point.R
@@ -8,7 +8,7 @@ data(meuse)
 # prepare the 3 components: coordinates, data, and proj4string
 coords <- meuse[ , c("x", "y")]   # coordinates
 data   <- meuse[ , 3:14]          # data
-crs    <- CRS("+init=epsg:28992") # proj4string of coords)
+crs    <- CRS("+init=epsg:28992") # proj4string of coords
 
 # make the spatial points data frame object
 spdf <- SpatialPointsDataFrame(coords = coords,


### PR DESCRIPTION
Added devtools::test(stop_on_failure = TRUE ), and moves its call from the after_success section to the script section (travis.yml file). This change enables Travis CI to fail builds when tests do not pass (as is the desired behavior of Travis CI).